### PR TITLE
Added authentification dialog in case of failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,22 @@ GCHelper is a Swift implementation for GameKit built off of the GameKitHelper cl
 > In the latest version of GCHelper, class functions were implemented so that using `sharedInstance` is not necessary. It can still be used if you want to, though.
 
 ### Authenticating the User
-Before doing anything with Game Center, the user needs to be signed in. This instance is often configured in your app's `application:didFinishLaunchingWithOptions:` method
+Before doing anything with Game Center, the user needs to be signed in. This instance is often configured in your app's `application:didFinishLaunchingWithOptions:` method.
+
+You will have to call `authentaticateLocalUser:`, which can show an authentification dialog if the user is not logged in, in the specified UIViewController. Passing `nil` to the second parameter will make the dialog show in the root view controller.
 
 ```swift
 func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
-    GCHelper.authenticateLocalUser()
+    GCHelper.sharedInstance.authenticateLocalUser(showAuthDialogOnFailure: true, inViewController: nil)
     return true
+}
+```
+
+You can also configure the instance in another view controller, like so:
+
+```swift
+func authenticateGameCenterUser() {
+    GCHelper.sharedInstance.authenticateLocalUser(showAuthDialogOnFailure: true, inViewController: self)
 }
 ```
 

--- a/Source/GCHelper.swift
+++ b/Source/GCHelper.swift
@@ -93,11 +93,21 @@ public class GCHelper: NSObject, GKMatchmakerViewControllerDelegate, GKGameCente
     
     // MARK: User functions
     
-    public func authenticateLocalUser() {
+    public func authenticateLocalUser(showAuthDialogOnFailure showAuthDialog: Bool, var inViewController viewController: UIViewController?) {
         print("Authenticating local user...")
         if GKLocalPlayer.localPlayer().authenticated == false {
             GKLocalPlayer.localPlayer().authenticateHandler = { (view, error) in
-                if error == nil {
+                if showAuthDialog && view != nil {
+                    if viewController == nil {
+                        if let rootViewController = UIApplication.sharedApplication().delegate?.window??.rootViewController {
+                            viewController = rootViewController
+                        }
+                    }
+                    
+                    if let _viewController = viewController {
+                        _viewController.presentViewController(view!, animated: true, completion: nil)
+                    }
+                } else if error == nil {
                     self.authenticated = true
                 } else {
                     print("\(error?.localizedDescription)")


### PR DESCRIPTION
If authentifaction fails, a dialog can be shown to ask the user to login.

This behaviour is specified in the call of `authenticateLocalUser:`, along with the view controller that should be associated with the dialog. Passing `nil` will make the dialog appear in the root view controller.